### PR TITLE
CredShield Audit Response

### DIFF
--- a/contracts/lib/BatchDeposit.sol
+++ b/contracts/lib/BatchDeposit.sol
@@ -17,6 +17,8 @@ import "../interfaces/IDepositContract.sol";
 contract BatchDeposit is Ownable, ReentrancyGuard {
     address immutable depositContract;
 
+    error NotPayable();
+
     uint256 constant PUBKEY_LENGTH = 48;
     uint256 constant SIGNATURE_LENGTH = 96;
     uint256 constant MAX_VALIDATORS_PER_BATCH = 100;
@@ -39,7 +41,7 @@ contract BatchDeposit is Ownable, ReentrancyGuard {
      * @dev This contract will not accept direct ETH transactions.
      */
     receive() external payable {
-        revert("This contract does not accept ETH being sent to it");
+        revert NotPayable();
     }
 
     /**

--- a/contracts/lib/BatchDeposit.sol
+++ b/contracts/lib/BatchDeposit.sol
@@ -15,14 +15,14 @@ import "../interfaces/IDepositContract.sol";
  * contract owner.
  */
 contract BatchDeposit is Ownable, ReentrancyGuard {
-    address immutable depositContract;
+    address private immutable depositContract;
 
     error NotPayable();
 
-    uint256 constant PUBKEY_LENGTH = 48;
-    uint256 constant SIGNATURE_LENGTH = 96;
-    uint256 constant MAX_VALIDATORS_PER_BATCH = 100;
-    uint256 constant DEPOSIT_AMOUNT = 32 ether;
+    uint256 private constant PUBKEY_LENGTH = 48;
+    uint256 private constant SIGNATURE_LENGTH = 96;
+    uint256 private constant MAX_VALIDATORS_PER_BATCH = 100;
+    uint256 private constant DEPOSIT_AMOUNT = 32 ether;
 
     mapping(bytes => bool) private _isValidatorAvailable;
 

--- a/contracts/lib/BatchDeposit.sol
+++ b/contracts/lib/BatchDeposit.sol
@@ -26,7 +26,7 @@ contract BatchDeposit is Ownable, ReentrancyGuard {
 
     mapping(bytes => bool) private _isValidatorAvailable;
 
-    event DepositEvent(address from, uint256 nodesAmount);
+    event Deposited(address from, uint256 nodesAmount);
 
     constructor(address depositContractAddr) {
         require(
@@ -181,6 +181,6 @@ contract BatchDeposit is Ownable, ReentrancyGuard {
             pubkeys
         );
 
-        emit DepositEvent(msg.sender, numberOfValidators);
+        emit Deposited(msg.sender, numberOfValidators);
     }
 }

--- a/contracts/lib/BatchDeposit.sol
+++ b/contracts/lib/BatchDeposit.sol
@@ -73,17 +73,21 @@ contract BatchDeposit is Ownable, ReentrancyGuard {
             "the number of validators to register must be greater than 0"
         );
 
-        for (uint256 i = 0; i < numberOfValidators; ++i) {
-            require(
-                pubkeys[i].length == PUBKEY_LENGTH,
-                "public key must be 48 bytes long"
-            );
-            require(
-                !_isValidatorAvailable[pubkeys[i]],
-                "validator is already registered"
-            );
+        for (uint256 i = 0; i < numberOfValidators; ) {
+            unchecked {
+                require(
+                    pubkeys[i].length == PUBKEY_LENGTH,
+                    "public key must be 48 bytes long"
+                );
+                require(
+                    !_isValidatorAvailable[pubkeys[i]],
+                    "validator is already registered"
+                );
 
-            _isValidatorAvailable[pubkeys[i]] = true;
+                _isValidatorAvailable[pubkeys[i]] = true;
+
+                ++i;
+            }
         }
     }
 
@@ -143,28 +147,34 @@ contract BatchDeposit is Ownable, ReentrancyGuard {
             "the number of deposit data roots must match the number of public keys"
         );
 
-        for (uint256 i = 0; i < numberOfValidators; ++i) {
-            require(
-                pubkeys[i].length == PUBKEY_LENGTH,
-                "public key must be 48 bytes long"
-            );
-            require(
-                signatures[i].length == SIGNATURE_LENGTH,
-                "signature must be 96 bytes long"
-            );
-            require(
-                _isValidatorAvailable[pubkeys[i]],
-                "validator is not available"
-            );
+        for (uint256 i = 0; i < numberOfValidators; ) {
+            unchecked {
+                require(
+                    pubkeys[i].length == PUBKEY_LENGTH,
+                    "public key must be 48 bytes long"
+                );
+                require(
+                    signatures[i].length == SIGNATURE_LENGTH,
+                    "signature must be 96 bytes long"
+                );
+                require(
+                    _isValidatorAvailable[pubkeys[i]],
+                    "validator is not available"
+                );
 
-            _isValidatorAvailable[pubkeys[i]] = false;
+                _isValidatorAvailable[pubkeys[i]] = false;
 
-            IDepositContract(depositContract).deposit{value: DEPOSIT_AMOUNT}(
-                pubkeys[i],
-                withdrawalCredential,
-                signatures[i],
-                depositDataRoots[i]
-            );
+                IDepositContract(depositContract).deposit{
+                    value: DEPOSIT_AMOUNT
+                }(
+                    pubkeys[i],
+                    withdrawalCredential,
+                    signatures[i],
+                    depositDataRoots[i]
+                );
+
+                ++i;
+            }
         }
 
         IStakingRewardsContract(stakingRewardsContract).activateValidators(

--- a/contracts/lib/StakingRewards.sol
+++ b/contracts/lib/StakingRewards.sol
@@ -186,7 +186,7 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
      */
     function exitValidator(
         bytes calldata pubkey
-    ) public virtual onlyRole(REWARDS_RECIPIENT_ROLE) {
+    ) external virtual onlyRole(REWARDS_RECIPIENT_ROLE) {
         require(
             pubkey.length == PUBKEY_LENGTH,
             "public key must be 48 bytes long"
@@ -205,7 +205,7 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
      * This function may only be called by the rewards recipient or fee recipient.
      * The recipient will receive the Ether they are owed since the last time they claimed.
      */
-    function release() public virtual {
+    function release() external virtual {
         require(
             hasRole(REWARDS_RECIPIENT_ROLE, msg.sender) ||
                 hasRole(FEE_RECIPIENT_ROLE, msg.sender),

--- a/contracts/lib/StakingRewards.sol
+++ b/contracts/lib/StakingRewards.sol
@@ -133,7 +133,7 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
             billableRewards = totalBalance - _exitedStake;
         }
 
-        if (account == _feeRecipient) {
+        if (account == _feeRecipient && billableRewards > 0) {
             uint256 totalFees = (billableRewards * _feeBasisPoints) / 10 ** 4;
             uint256 releasedFees = released(_feeRecipient);
             return totalFees - releasedFees;

--- a/contracts/lib/StakingRewards.sol
+++ b/contracts/lib/StakingRewards.sol
@@ -5,8 +5,6 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
 interface IStakingRewardsContract {
-    event DidUpdateNumberOfActiveValidators(uint256 numberOfActiveValidators);
-
     function activateValidators(bytes[] calldata pubkeys) external;
 }
 
@@ -41,6 +39,8 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
     uint256 private constant MAX_BASIS_POINTS = 10000;
 
     event PaymentReleased(address to, uint256 amount);
+    event ValidatorExited(bytes exitedValidatorPublicKey);
+    event ValidatorsActivated(bytes[] validatorPublicKeys);
 
     address private immutable _depositContract;
     address payable private immutable _rewardsRecipient;
@@ -182,7 +182,7 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
         _numberOfActiveValidators =
             _numberOfActiveValidators +
             numberOfPublicKeys;
-        emit DidUpdateNumberOfActiveValidators(_numberOfActiveValidators);
+        emit ValidatorsActivated(pubkeys);
     }
 
     /**
@@ -204,7 +204,7 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
         _isActiveValidator[pubkey] = false;
         _numberOfActiveValidators = _numberOfActiveValidators - 1;
         _exitedStake = _exitedStake + STAKE_PER_VALIDATOR;
-        emit DidUpdateNumberOfActiveValidators(_numberOfActiveValidators);
+        emit ValidatorExited(pubkey);
     }
 
     /**

--- a/contracts/lib/StakingRewards.sol
+++ b/contracts/lib/StakingRewards.sol
@@ -160,17 +160,22 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
     ) public virtual onlyRole(DEPOSITOR_ROLE) {
         require(pubkeys.length > 0, "no validators to activate");
 
-        for (uint256 i = 0; i < pubkeys.length; ++i) {
-            require(
-                pubkeys[i].length == PUBKEY_LENGTH,
-                "public key must be 48 bytes long"
-            );
-            // require validator not active already
-            require(
-                !_isActiveValidator[pubkeys[i]],
-                "validator is already active"
-            );
-            _isActiveValidator[pubkeys[i]] = true;
+        for (uint256 i = 0; i < pubkeys.length; ) {
+            unchecked {
+                require(
+                    pubkeys[i].length == PUBKEY_LENGTH,
+                    "public key must be 48 bytes long"
+                );
+                // require validator not active already
+                require(
+                    !_isActiveValidator[pubkeys[i]],
+                    "validator is already active"
+                );
+
+                _isActiveValidator[pubkeys[i]] = true;
+
+                ++i;
+            }
         }
         _numberOfActiveValidators += pubkeys.length;
         emit DidUpdateNumberOfActiveValidators(_numberOfActiveValidators);

--- a/contracts/lib/StakingRewards.sol
+++ b/contracts/lib/StakingRewards.sol
@@ -160,7 +160,7 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
     ) public virtual onlyRole(DEPOSITOR_ROLE) {
         require(pubkeys.length > 0, "no validators to activate");
 
-        for (uint256 i = 0; i < pubkeys.length; i++) {
+        for (uint256 i = 0; i < pubkeys.length; ++i) {
             require(
                 pubkeys[i].length == PUBKEY_LENGTH,
                 "public key must be 48 bytes long"

--- a/contracts/lib/StakingRewards.sol
+++ b/contracts/lib/StakingRewards.sol
@@ -158,9 +158,11 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
     function activateValidators(
         bytes[] calldata pubkeys
     ) public virtual onlyRole(DEPOSITOR_ROLE) {
-        require(pubkeys.length > 0, "no validators to activate");
+        uint256 numberOfPublicKeys = pubkeys.length;
 
-        for (uint256 i = 0; i < pubkeys.length; ) {
+        require(numberOfPublicKeys > 0, "no validators to activate");
+
+        for (uint256 i = 0; i < numberOfPublicKeys; ) {
             unchecked {
                 require(
                     pubkeys[i].length == PUBKEY_LENGTH,
@@ -177,7 +179,9 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
                 ++i;
             }
         }
-        _numberOfActiveValidators = _numberOfActiveValidators + pubkeys.length;
+        _numberOfActiveValidators =
+            _numberOfActiveValidators +
+            numberOfPublicKeys;
         emit DidUpdateNumberOfActiveValidators(_numberOfActiveValidators);
     }
 

--- a/contracts/lib/StakingRewards.sol
+++ b/contracts/lib/StakingRewards.sol
@@ -36,9 +36,9 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
     bytes32 public constant REWARDS_RECIPIENT_ROLE =
         keccak256("REWARDS_RECIPIENT_ROLE");
 
-    uint256 constant PUBKEY_LENGTH = 48;
-    uint256 constant STAKE_PER_VALIDATOR = 32 ether;
-    uint256 constant MAX_BASIS_POINTS = 10000;
+    uint256 private constant PUBKEY_LENGTH = 48;
+    uint256 private constant STAKE_PER_VALIDATOR = 32 ether;
+    uint256 private constant MAX_BASIS_POINTS = 10000;
 
     event PaymentReleased(address to, uint256 amount);
 

--- a/contracts/lib/StakingRewards.sol
+++ b/contracts/lib/StakingRewards.sol
@@ -177,7 +177,7 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
                 ++i;
             }
         }
-        _numberOfActiveValidators += pubkeys.length;
+        _numberOfActiveValidators = _numberOfActiveValidators + pubkeys.length;
         emit DidUpdateNumberOfActiveValidators(_numberOfActiveValidators);
     }
 
@@ -198,8 +198,8 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
         );
         require(_isActiveValidator[pubkey], "validator is not active");
         _isActiveValidator[pubkey] = false;
-        _numberOfActiveValidators -= 1;
-        _exitedStake += STAKE_PER_VALIDATOR;
+        _numberOfActiveValidators = _numberOfActiveValidators - 1;
+        _exitedStake = _exitedStake + STAKE_PER_VALIDATOR;
         emit DidUpdateNumberOfActiveValidators(_numberOfActiveValidators);
     }
 
@@ -224,9 +224,9 @@ contract StakingRewards is AccessControl, IStakingRewardsContract {
 
         require(releasableFunds > 0, "there are currently no funds to release");
 
-        _totalReleased += releasableFunds;
+        _totalReleased = _totalReleased + releasableFunds;
         unchecked {
-            _released[recipient] += releasableFunds;
+            _released[recipient] = _released[recipient] + releasableFunds;
         }
 
         emit PaymentReleased(recipient, releasableFunds);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@openzeppelin/contracts": "^4.9.3",
         "ethers": "^6.7.1",
-        "hardhat": "^2.17.2"
+        "hardhat": "^2.17.2",
+        "prettier-plugin-solidity": "^1.1.3"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^3.0.0",
@@ -26,7 +27,6 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "^2.28.1",
         "prettier": "^3.0.3",
-        "prettier-plugin-solidity": "^1.1.3",
         "solhint": "^3.6.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
@@ -1792,9 +1792,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-verify/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -2146,9 +2146,9 @@
       }
     },
     "node_modules/@openzeppelin/test-helpers/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -2345,7 +2345,6 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.0.tgz",
       "integrity": "sha512-ESipEcHyRHg4Np4SqBCfcXwyxxna1DgFVz69bgpLV8vzl/NP1DtcKsJ4dJZXWQhY/Z4J2LeKBiOkOVZn9ct33Q==",
-      "dev": true,
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
@@ -2363,62 +2362,74 @@
       }
     },
     "node_modules/@truffle/abi-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@truffle/abi-utils/-/abi-utils-1.0.1.tgz",
-      "integrity": "sha512-ZQUY3XUxEPdqxNaoXsOqF0spTtb6f5RNlnN4MUrVsJ64sOh0FJsY7rxZiUI3khfePmNh4i2qcJrQlKT36YcWUA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@truffle/abi-utils/-/abi-utils-1.0.3.tgz",
+      "integrity": "sha512-AWhs01HCShaVKjml7Z4AbVREr/u4oiWxCcoR7Cktm0mEvtT04pvnxW5xB/cI4znRkrbPdFQlFt67kgrAjesYkw==",
       "dev": true,
       "dependencies": {
         "change-case": "3.0.2",
         "fast-check": "3.1.1",
         "web3-utils": "1.10.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
       }
     },
     "node_modules/@truffle/blockchain-utils": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.1.8.tgz",
-      "integrity": "sha512-ZskpYDNHkXD3ota4iU3pZz6kLth87RC+wDn66Rp2Or+DqqJCKdnmS9GDctBi1EcMPDEi0BqpkdrfBuzA9uIkGg==",
-      "dev": true
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.1.9.tgz",
+      "integrity": "sha512-RHfumgbIVo68Rv9ofDYfynjnYZIfP/f1vZy4RoqkfYAO+fqfc58PDRzB1WAGq2U6GPuOnipOJxQhnqNnffORZg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
+      }
     },
     "node_modules/@truffle/codec": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.15.3.tgz",
-      "integrity": "sha512-8dRxZEaPS+Qo9v90zl+zQ8RSSqNCd88yrdUS5mSfEGMsmiixR5l3R85c8QfV73B4WNYlMLTa9mC0JmhG1vqz2Q==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.17.3.tgz",
+      "integrity": "sha512-Ko/+dsnntNyrJa57jUD9u4qx9nQby+H4GsUO6yjiCPSX0TQnEHK08XWqBSg0WdmCH2+h0y1nr2CXSx8gbZapxg==",
       "dev": true,
       "dependencies": {
-        "@truffle/abi-utils": "^1.0.1",
-        "@truffle/compile-common": "^0.9.6",
+        "@truffle/abi-utils": "^1.0.3",
+        "@truffle/compile-common": "^0.9.8",
         "big.js": "^6.0.3",
         "bn.js": "^5.1.3",
         "cbor": "^5.2.0",
         "debug": "^4.3.1",
         "lodash": "^4.17.21",
-        "semver": "7.3.7",
+        "semver": "^7.5.4",
         "utf8": "^3.0.0",
         "web3-utils": "1.10.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
       }
     },
     "node_modules/@truffle/compile-common": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@truffle/compile-common/-/compile-common-0.9.6.tgz",
-      "integrity": "sha512-TCcmr1E0GqMZJ2tOaCRNEllxTBJ/g7TuD6jDJpw5Gt9Bw0YO3Cmp6yPQRynRSO4xMJbHUgiEsSfRgIhswut5UA==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@truffle/compile-common/-/compile-common-0.9.8.tgz",
+      "integrity": "sha512-DTpiyo32t/YhLI1spn84D3MHYHrnoVqO+Gp7ZHrYNwDs86mAxtNiH5lsVzSb8cPgiqlvNsRCU9nm9R0YmKMTBQ==",
       "dev": true,
       "dependencies": {
-        "@truffle/error": "^0.2.1",
+        "@truffle/error": "^0.2.2",
         "colors": "1.4.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
       }
     },
     "node_modules/@truffle/contract": {
-      "version": "4.6.24",
-      "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.6.24.tgz",
-      "integrity": "sha512-YdF0lXPrhgQk+St8pHh9u+bvu8N7w3Yn1ni70KVIJiizs2YV6bJkkyEp8uBmMpTpuPwXczkL9HHYFMhDBCbEhQ==",
+      "version": "4.6.31",
+      "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.6.31.tgz",
+      "integrity": "sha512-s+oHDpXASnZosiCdzu+X1Tx5mUJUs1L1CYXIcgRmzMghzqJkaUFmR6NpNo7nJYliYbO+O9/aW8oCKqQ7rCHfmQ==",
       "dev": true,
       "dependencies": {
         "@ensdomains/ensjs": "^2.1.0",
-        "@truffle/blockchain-utils": "^0.1.8",
-        "@truffle/contract-schema": "^3.4.14",
-        "@truffle/debug-utils": "^6.0.52",
-        "@truffle/error": "^0.2.1",
-        "@truffle/interface-adapter": "^0.5.34",
+        "@truffle/blockchain-utils": "^0.1.9",
+        "@truffle/contract-schema": "^3.4.16",
+        "@truffle/debug-utils": "^6.0.57",
+        "@truffle/error": "^0.2.2",
+        "@truffle/interface-adapter": "^0.5.37",
         "bignumber.js": "^7.2.1",
         "debug": "^4.3.1",
         "ethers": "^4.0.32",
@@ -2427,16 +2438,22 @@
         "web3-core-promievent": "1.10.0",
         "web3-eth-abi": "1.10.0",
         "web3-utils": "1.10.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
       }
     },
     "node_modules/@truffle/contract-schema": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.4.14.tgz",
-      "integrity": "sha512-IwVQZG9RVNwTdn321+jbFIcky3/kZLkCtq8tqil4jZwivvmZQg8rIVC8GJ7Lkrmixl9/yTyQNL6GtIUUvkZxyA==",
+      "version": "3.4.16",
+      "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.4.16.tgz",
+      "integrity": "sha512-g0WNYR/J327DqtJPI70ubS19K1Fth/1wxt2jFqLsPmz5cGZVjCwuhiie+LfBde4/Mc9QR8G+L3wtmT5cyoBxAg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.10.0",
         "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
       }
     },
     "node_modules/@truffle/contract-schema/node_modules/ajv": {
@@ -2529,17 +2546,20 @@
       "dev": true
     },
     "node_modules/@truffle/debug-utils": {
-      "version": "6.0.52",
-      "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-6.0.52.tgz",
-      "integrity": "sha512-lciQ79OovlLWp+9CzV8mvrJwpxiN0R+qxKyHos/kMVFbLPZ4lvhmSu5wi6Uf7LaeMBtC3ujRBqVUyv6mV7WVzA==",
+      "version": "6.0.57",
+      "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-6.0.57.tgz",
+      "integrity": "sha512-Q6oI7zLaeNLB69ixjwZk2UZEWBY6b2OD1sjLMGDKBGR7GaHYiw96GLR2PFgPH1uwEeLmV4N78LYaQCrDsHbNeA==",
       "dev": true,
       "dependencies": {
-        "@truffle/codec": "^0.15.3",
+        "@truffle/codec": "^0.17.3",
         "@trufflesuite/chromafi": "^3.0.0",
         "bn.js": "^5.1.3",
         "chalk": "^2.4.2",
         "debug": "^4.3.1",
         "highlightjs-solidity": "^2.0.6"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
       }
     },
     "node_modules/@truffle/debug-utils/node_modules/ansi-styles": {
@@ -2614,20 +2634,26 @@
       }
     },
     "node_modules/@truffle/error": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.2.1.tgz",
-      "integrity": "sha512-5Qy+z9dg9hP37WNdLnXH4b9MzemWrjTufRq7/DTKqimjyxCP/1zlL8gQEMdiSx1BBtAZz0xypkID/jb7AF/Osg==",
-      "dev": true
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.2.2.tgz",
+      "integrity": "sha512-TqbzJ0O8DHh34cu8gDujnYl4dUl6o2DE4PR6iokbybvnIm/L2xl6+Gv1VC+YJS45xfH83Yo3/Zyg/9Oq8/xZWg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
+      }
     },
     "node_modules/@truffle/interface-adapter": {
-      "version": "0.5.34",
-      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.34.tgz",
-      "integrity": "sha512-gPxabfMi2TueE4VxnNuyeudOfvGJQ1ofVC02PFw14cnRQhzH327JikjjQbZ1bT6S7kWl9H6P3hQPFeYFMHdm1g==",
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.37.tgz",
+      "integrity": "sha512-lPH9MDgU+7sNDlJSClwyOwPCfuOimqsCx0HfGkznL3mcFRymc1pukAR1k17zn7ErHqBwJjiKAZ6Ri72KkS+IWw==",
       "dev": true,
       "dependencies": {
         "bn.js": "^5.1.3",
         "ethers": "^4.0.32",
         "web3": "1.10.0"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.16 || >=20"
       }
     },
     "node_modules/@truffle/interface-adapter/node_modules/ethers": {
@@ -3084,21 +3110,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
@@ -3211,21 +3222,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
@@ -3249,21 +3245,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -3496,8 +3477,7 @@
     "node_modules/antlr4ts": {
       "version": "0.5.0-alpha.4",
       "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
-      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
-      "dev": true
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ=="
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -5779,9 +5759,9 @@
       }
     },
     "node_modules/eslint-config-airbnb-base/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -8297,9 +8277,9 @@
       }
     },
     "node_modules/hardhat/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8347,9 +8327,9 @@
       }
     },
     "node_modules/hardhat/node_modules/solc/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -9616,7 +9596,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10189,9 +10168,9 @@
       }
     },
     "node_modules/node-environment-flags/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -10263,9 +10242,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -10839,7 +10818,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
-      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10854,7 +10832,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.1.3.tgz",
       "integrity": "sha512-fQ9yucPi2sBbA2U2Xjh6m4isUTJ7S7QLc/XDDsktqqxYfTwdYKJ0EnnywXHwCGAaYbQNK+HIYPL1OemxuMsgeg==",
-      "dev": true,
       "dependencies": {
         "@solidity-parser/parser": "^0.16.0",
         "semver": "^7.3.8",
@@ -10865,21 +10842,6 @@
       },
       "peerDependencies": {
         "prettier": ">=2.3.0 || >=3.0.0-alpha.0"
-      }
-    },
-    "node_modules/prettier-plugin-solidity/node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/process": {
@@ -11776,10 +11738,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12170,9 +12131,9 @@
       }
     },
     "node_modules/solc/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -12352,36 +12313,20 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/solhint/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/solidity-comments-extractor": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
-      "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
-      "dev": true
+      "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw=="
     },
     "node_modules/solidity-coverage": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.3.tgz",
-      "integrity": "sha512-hbcNgj5z8zzgTlnp4F0pXiqj1v5ua8P4DH5i9cWOBtFPfUuIohLoXu5WiAixexWmpKVjyxXqupnu/mPb4IGr7Q==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.4.tgz",
+      "integrity": "sha512-xeHOfBOjdMF6hWTbt42iH4x+7j1Atmrf5OldDPMxI+i/COdExUxszOswD9qqvcBTaLGiOrrpnh9UZjSpt4rBsg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.0.9",
-        "@solidity-parser/parser": "^0.14.1",
+        "@solidity-parser/parser": "^0.16.0",
         "chalk": "^2.4.2",
         "death": "^1.1.0",
         "detect-port": "^1.3.0",
@@ -12406,16 +12351,6 @@
       },
       "peerDependencies": {
         "hardhat": "^2.11.0"
-      }
-    },
-    "node_modules/solidity-coverage/node_modules/@solidity-parser/parser": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
-      "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "antlr4ts": "^0.5.0-alpha.4"
       }
     },
     "node_modules/solidity-coverage/node_modules/ansi-colors": {
@@ -14962,9 +14897,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -15122,8 +15057,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:sol": "solhint 'contracts/**/*.sol' 'test/**/*.sol'",
     "lint:ts": "eslint tasks test",
     "analyze": "slither contracts/lib",
-    "fmt": "prettier --write contracts tasks test"
+    "fmt": "prettier --write --plugin=prettier-plugin-solidity contracts tasks test"
   },
   "repository": {
     "type": "git",

--- a/test/BatchDeposit.test.ts
+++ b/test/BatchDeposit.test.ts
@@ -220,7 +220,7 @@ describe("BatchDeposit", async () => {
         expectedPaymentAmount,
       );
       await expect(res)
-        .to.emit(this.batchDepositContract, "DepositEvent")
+        .to.emit(this.batchDepositContract, "Deposited")
         .withArgs(payee1.address, numberOfNodes);
     });
 

--- a/test/BatchDeposit.test.ts
+++ b/test/BatchDeposit.test.ts
@@ -121,6 +121,20 @@ describe("BatchDeposit", async () => {
     );
   });
 
+  describe("not payable", async () => {
+    it("throws a custom error `NotPayable` when trying to send ETH", async function () {
+      const [_deployer, _justfarmingFeeWallet, _customer, randomUser] =
+        await ethers.getSigners();
+
+      await expect(
+        randomUser.sendTransaction({
+          to: this.batchDepositContract.target,
+          value: ethers.parseEther("1.0"),
+        }),
+      ).to.be.revertedWithCustomError(this.batchDepositContract, "NotPayable");
+    });
+  });
+
   describe("validator registration", async () => {
     it("is allowed with valid validator public keys", async function () {
       const [owner, nobody] = await ethers.getSigners();

--- a/test/BatchDeposit.test.ts
+++ b/test/BatchDeposit.test.ts
@@ -168,6 +168,38 @@ describe("BatchDeposit", async () => {
       ).to.be.revertedWith("validator is already registered");
     });
 
+    it("reverts if a validator has already been registered *and* activated", async function () {
+      const [owner, payee1] = await ethers.getSigners();
+      const numberOfNodes = 1;
+
+      const validatorDeposits = createValidatorDeposits(
+        this.stakingRewardsContract.target,
+        numberOfNodes,
+      );
+
+      await this.batchDepositContract
+        .connect(owner)
+        .registerValidators(validatorDeposits.pubkeys);
+
+      await this.batchDepositContract
+        .connect(payee1)
+        .batchDeposit(
+          validatorDeposits.withdrawalAddress,
+          validatorDeposits.pubkeys,
+          validatorDeposits.signatures,
+          validatorDeposits.depositDataRoots,
+          {
+            value: validatorDeposits.amount,
+          },
+        );
+
+      await expect(
+        this.batchDepositContract
+          .connect(owner)
+          .registerValidators(validatorDeposits.pubkeys),
+      ).to.be.revertedWith("validator is or was active");
+    });
+
     it("reverts if a validator public key is invalid", async function () {
       const [owner] = await ethers.getSigners();
 

--- a/test/StakingRewards.test.ts
+++ b/test/StakingRewards.test.ts
@@ -194,6 +194,26 @@ describe("StakingRewards", async () => {
       ).to.be.revertedWith(`validator is already active`);
     });
 
+    it("emits `ValidatorsActivated` upon activation of validators and `ValidatorExited` upon successful exit", async function () {
+      const validatorPublicKey = `0x${"01".repeat(48)}`;
+
+      let res = await this.stakingRewardsContract
+        .connect(this.deployer)
+        .activateValidators([validatorPublicKey]);
+
+      await expect(res)
+        .to.emit(this.stakingRewardsContract, "ValidatorsActivated")
+        .withArgs([validatorPublicKey]);
+
+      res = await this.stakingRewardsContract
+        .connect(this.customer)
+        .exitValidator(validatorPublicKey);
+
+      await expect(res)
+        .to.emit(this.stakingRewardsContract, "ValidatorExited")
+        .withArgs(validatorPublicKey);
+    });
+
     it("prevents exiting a validator that has not been added", async function () {
       const validatorPublicKey = `0x${"01".repeat(48)}`;
       await expect(


### PR DESCRIPTION
# CredShield Audit Response

This PR is dedicated to addressing any notes received during the CredShield audit of the Justfarming BatchDeposit and StakingRewards contracts.

### Mitigate potential uint underflow in StakingRewards.sol

CredShields have reported a potential uint underflow in the StakingRewards:releasable function.

Scenario:
1. The message caller of `releasable` is the `feeRecipient`
2. `billableRewards` are `0` because of a pending validator withdrawal.
3. `totalFees`, being a multiplicative of `billableRewards`, is `0`
4. `releasedFees`, i.e., the total of previously released fees, is (strictly) greater than `0`
5. `totalFees - releasedFees` underflows

Validation:
The test case added in this commit confirms the assumption. Prior to implementing the mitigation, the added test failed because the transaction `reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)`.

Mitigation:
The calculation of `releasable` fees checks whether there are any `billableRewards` applicable for fee emission.